### PR TITLE
Fix production build: Remove hardcoded development mode from SWC config

### DIFF
--- a/.swcrc
+++ b/.swcrc
@@ -12,8 +12,7 @@
     },
     "transform": {
       "react": {
-        "runtime": "automatic",
-        "development": true
+        "runtime": "automatic"
       }
     },
     "externalHelpers": false,


### PR DESCRIPTION
The .swcrc file was forcing React development mode with jsxDEV transforms, which caused 'jsxDEV is not a function' errors in production builds. Removed the hardcoded development flag to let SWC determine mode from webpack.

## Summary

Describe the change and the problem it solves.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor/Chore
- [ ] Documentation

## How has this been tested?

Describe the tests you ran and provide instructions so we can reproduce.

## Checklist

- [ ] I ran type checks and tests locally
- [ ] I updated or added tests as needed
- [ ] I updated documentation (README/CHANGELOG) as needed
- [ ] I have read the Code of Conduct and Contributing guidelines

## Screenshots/Recordings (if applicable)
